### PR TITLE
Add basic TLS circuit breaker for Redis

### DIFF
--- a/registry/handlers/app.go
+++ b/registry/handlers/app.go
@@ -493,59 +493,93 @@ func (app *App) configureEvents(configuration *configuration.Configuration) {
 
 type redisStartAtKey struct{}
 
+var circuitTripped = false
+
 func (app *App) configureRedis(configuration *configuration.Configuration) {
 	if configuration.Redis.Addr == "" {
 		dcontext.GetLogger(app).Infof("redis not configured")
 		return
 	}
 
-	pool := &redis.Pool{
-		Dial: func() (redis.Conn, error) {
-			// TODO(stevvooe): Yet another use case for contextual timing.
-			ctx := context.WithValue(app, redisStartAtKey{}, time.Now())
+	// TLS if the redis addr is prefixed with "rediss://"
+	useTLS := configuration.Redis.Addr[0:8] == "rediss://"
 
-			done := func(err error) {
-				logger := dcontext.GetLoggerWithField(ctx, "redis.connect.duration",
-					dcontext.Since(ctx, redisStartAtKey{}))
-				if err != nil {
-					logger.Errorf("redis: error connecting: %v", err)
-				} else {
-					logger.Infof("redis: connect %v", configuration.Redis.Addr)
-				}
-			}
+	dial := func(forceTLS bool) (redis.Conn, error) {
+		// TODO(stevvooe): Yet another use case for contextual timing.
+		ctx := context.WithValue(app, redisStartAtKey{}, time.Now())
 
-			conn, err := redis.Dial("tcp",
-				configuration.Redis.Addr,
-				redis.DialConnectTimeout(configuration.Redis.DialTimeout),
-				redis.DialReadTimeout(configuration.Redis.ReadTimeout),
-				redis.DialWriteTimeout(configuration.Redis.WriteTimeout))
+		done := func(err error) {
+			logger := dcontext.GetLoggerWithField(ctx, "redis.connect.duration",
+				dcontext.Since(ctx, redisStartAtKey{}))
 			if err != nil {
-				dcontext.GetLogger(app).Errorf("error connecting to redis instance %s: %v",
-					configuration.Redis.Addr, err)
+				logger.Errorf("redis: error connecting: %v", err)
+			} else {
+				logger.Infof("redis: connect %v", configuration.Redis.Addr)
+			}
+		}
+
+		conn, err := redis.Dial("tcp",
+			configuration.Redis.Addr,
+			redis.DialConnectTimeout(configuration.Redis.DialTimeout),
+			redis.DialReadTimeout(configuration.Redis.ReadTimeout),
+			redis.DialWriteTimeout(configuration.Redis.WriteTimeout),
+			redis.DialUseTLS(forceTLS),
+			redis.DialTLSSkipVerify(true),
+		)
+		if err != nil {
+			dcontext.GetLogger(app).Errorf("error connecting to redis instance %s: %v",
+				configuration.Redis.Addr, err)
+			done(err)
+			return nil, err
+		}
+
+		// authorize the connection
+		if configuration.Redis.Password != "" {
+			if _, err = conn.Do("AUTH", configuration.Redis.Password); err != nil {
+				defer conn.Close()
 				done(err)
 				return nil, err
 			}
+		}
 
-			// authorize the connection
-			if configuration.Redis.Password != "" {
-				if _, err = conn.Do("AUTH", configuration.Redis.Password); err != nil {
-					defer conn.Close()
-					done(err)
-					return nil, err
+		// select the database to use
+		if configuration.Redis.DB != 0 {
+			if _, err = conn.Do("SELECT", configuration.Redis.DB); err != nil {
+				defer conn.Close()
+				done(err)
+				return nil, err
+			}
+		}
+
+		done(nil)
+		return conn, nil
+	}
+
+	pool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			// if we have a TLS address or the circuit is tripped - dial with TLS always
+			if useTLS || circuitTripped {
+				return dial(true)
+			}
+
+			// otherwise - attempt to dial without TLS
+			conn, err := dial(false)
+
+			// if we get an error - try dialing with TLS
+			if err != nil && !circuitTripped {
+				dcontext.GetLogger(app).Errorf("redis_pool error: %v", err)
+				tlsConn, tlsErr := dial(true)
+
+				// there was no error, force TLS by setting the circuit to tripped
+				// otherwise, don't use this attempt and return the original error
+				if tlsErr == nil {
+					circuitTripped = true
+					dcontext.GetLogger(app).Info("count#redis.circuit.open: 1")
+					return tlsConn, tlsErr
 				}
 			}
 
-			// select the database to use
-			if configuration.Redis.DB != 0 {
-				if _, err = conn.Do("SELECT", configuration.Redis.DB); err != nil {
-					defer conn.Close()
-					done(err)
-					return nil, err
-				}
-			}
-
-			done(nil)
-			return conn, nil
+			return conn, err
 		},
 		MaxIdle:     configuration.Redis.Pool.MaxIdle,
 		MaxActive:   configuration.Redis.Pool.MaxActive,


### PR DESCRIPTION
We want to allow an easy transition to TLS for Redis. This commit adds a circuit breaker that will allow us to switch between TLS and non-TLS Redis connections. The circuit breaker will be removed once we have fully transitioned to TLS.