### PR TITLE
Add s3.TransportWrapper

### DIFF
--- a/registry/storage/driver/s3-aws/s3.go
+++ b/registry/storage/driver/s3-aws/s3.go
@@ -80,7 +80,7 @@ var validRegions = map[string]struct{}{}
 // validObjectACLs contains known s3 object Acls
 var validObjectACLs = map[string]struct{}{}
 
-//DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
+// DriverParameters A struct that encapsulates all of the driver parameters after all values have been set
 type DriverParameters struct {
 	AccessKey                   string
 	SecretKey                   string
@@ -101,6 +101,7 @@ type DriverParameters struct {
 	UserAgent                   string
 	ObjectACL                   string
 	SessionToken                string
+	TransportWrapper            func(http.RoundTripper) http.RoundTripper
 }
 
 func init() {
@@ -359,6 +360,7 @@ func FromParameters(parameters map[string]interface{}) (*Driver, error) {
 		fmt.Sprint(userAgent),
 		objectACL,
 		fmt.Sprint(sessionToken),
+		nil,
 	}
 
 	return New(params)
@@ -437,6 +439,14 @@ func New(params DriverParameters) (*Driver, error) {
 				Transport: transport.NewTransport(httpTransport),
 			})
 		}
+	}
+
+	if params.TransportWrapper != nil {
+		existing := awsConfig.HTTPClient
+		if existing == nil {
+			existing = http.DefaultClient
+		}
+		awsConfig.WithHTTPClient(&http.Client{Transport: params.TransportWrapper(existing.Transport)})
 	}
 
 	sess, err := session.NewSession(awsConfig)

--- a/registry/storage/driver/s3-aws/s3_test.go
+++ b/registry/storage/driver/s3-aws/s3_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"math/rand"
+	"net/http"
 	"os"
 	"reflect"
 	"strconv"
@@ -21,6 +22,38 @@ import (
 
 // Hook up gocheck into the "go test" runner.
 func Test(t *testing.T) { check.TestingT(t) }
+
+func TestTransportWrapper(t *testing.T) {
+	var wrapped bool
+	wrapper := func(rt http.RoundTripper) http.RoundTripper {
+		wrapped = true
+		return rt
+	}
+
+	params := DriverParameters{
+		AccessKey:                   "key",
+		SecretKey:                   "secret",
+		Bucket:                      "bucket",
+		Region:                      "us-east-1",
+		RegionEndpoint:              "http://localhost",
+		V4Auth:                      true,
+		Secure:                      false,
+		ChunkSize:                   minChunkSize,
+		MultipartCopyChunkSize:      defaultMultipartCopyChunkSize,
+		MultipartCopyMaxConcurrency: defaultMultipartCopyMaxConcurrency,
+		MultipartCopyThresholdSize:  defaultMultipartCopyThresholdSize,
+		StorageClass:                s3.StorageClassStandard,
+		TransportWrapper:            wrapper,
+	}
+
+	_, err := New(params)
+	if err != nil {
+		t.Fatalf("unexpected error creating driver: %v", err)
+	}
+	if !wrapped {
+		t.Fatal("expected TransportWrapper to be called, but it was not")
+	}
+}
 
 var s3DriverConstructor func(rootDirectory, storageClass string) (*Driver, error)
 var skipS3 func() string
@@ -97,6 +130,7 @@ func init() {
 			driverName + "-test",
 			objectACL,
 			sessionToken,
+			nil,
 		}
 
 		return New(parameters)


### PR DESCRIPTION
This adds a wrapper for the http.Transport used for S3 that will allow clients to decorate the transport with things like OTEL middleware.